### PR TITLE
fixed websocket fallback for browsers that don't support websocket

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -18,6 +18,7 @@ var modals = {
 var web_sock = undefined;
 var web_sock_queue = [];
 var web_sock_id = 0;
+var web_sock_support = typeof WebSocket != "undefined" ? 1 : 0;
 var clear_dialogs = function() {
 	for(var i in modals) {
 		modals[i].modal('hide');
@@ -170,7 +171,7 @@ var jsonp_syscall = function(conf, multicall) {
 	});
 }
 var aria_syscall = function(conf, multicall) {
-	if(!WebSocket || server_conf.user.length || server_conf.pass.length) {
+	if(!web_sock_support || server_conf.user.length || server_conf.pass.length) {
 		jsonp_syscall(conf, multicall);
 	}
 	else if(web_sock) {
@@ -206,7 +207,7 @@ $(function() {
 	modals.new_torrent_modal = $('#new_torrent').modal(modal_conf);
 	modals.new_metalink_modal = $('#new_metalink').modal(modal_conf);
 
-	if(WebSocket)
+	if(web_sock_support)
 		web_sock_init();
 
 	update_ui();


### PR DESCRIPTION
- repro: open webui-aria2 in any browser that doesn't have native websocket support in its javascript library (example: Opera 12.01, IE9), and none of the functionality in webui-aria2 will work due to javascript errors
- see: http://en.wikipedia.org/wiki/WebSocket#Browser_support (Note that Firefox has websocket support, but calls its object "MozWebSocket" instead of "WebSocket", so this issue applies there too)
- there were a few places in script.js that check for websocket support by doing something like "if(WebSocket)" to see if the WebSocket object exists
- javascript doesn't handle undefined variables that way, the interpreter will actually throw an "undefined variable" error and stop execution of the script
- this means that any browser that doesn't have websocket support can never reach the fallback json call code
- added a new variable "web_sock_support" that does a proper "undefined" check, and is set to "1" if the "WebSocket" object is available in the browser
- changed the websocket checks to use the "web_sock_support" variable
