### PR TITLE
fixing misc javascript syntax errors

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -34,7 +34,7 @@ var set_conf_cookie = function() {
 	setCookie('aria2_server_conf', JSON.stringify(server_conf), 30 * 12);
 }
 var get_conf_cookie = function() {
-	if (getCookie('aria2_server_conf'.trim())) {
+	if (getCookie( $.trim('aria2_server_conf'))) {
 		server_conf = JSON.parse(getCookie('aria2_server_conf'));
 	}
 }
@@ -507,7 +507,7 @@ function getTemplateCtx(data) {
 		connections: data.connections,
 		upload_speed: changeLength(data.uploadSpeed, "B/s"),
 		booleans: {
-			is_error: data.status === "error",
+			is_error: data.status === "error"
 		},
 		chunks: chunks,
 		bittorrent: !!data.bittorrent


### PR DESCRIPTION
- these are nitpicky things that some browsers just step right over silently, and others halt script execution for
- the jquery trim function only works on variables that have been returned as jquery objects, so doing "'foo'.trim()" doesn't work, should be "$.trim('foo')"
- some javascript interpreters (annoyingly) can't handle trailing commas in lists
