### PR TITLE
[PATCH] Add SSL/TLS encryption

### DIFF
--- a/index.html
+++ b/index.html
@@ -573,6 +573,13 @@
 						<input type="text" class="input-xlarge" placeholder="6800" id="input_port"/>
 						<p class="help-block">Enter the port of the server on which the rpc for aria2 is running (default = 6800)</p>
 					</div>
+
+					<label class="control-label" for="input_encryption">SSL/TLS encryption:</label>
+					<div class="controls">
+						<button type="button" class="btn" data-toggle="button" id="input_encryption">ON</button>
+						<p class="help-block">Enable SSL/TLS encryption.</p>
+					</div>
+
 					<label class="control-label" for="input_user">Enter the username (optional):</label>
 					<div class="controls">
 						<input type="text" class="input-xlarge" id="input_user"/>

--- a/js/connection.js
+++ b/js/connection.js
@@ -30,8 +30,9 @@ JsonRPC.prototype = {
 	},
 	invoke: function(opts) {
 		var rpc = this;
+		var scheme = rpc.serverConf.encryption ? 'https' : 'http';
 		rpc.ariaRequest(
-			'http://' + rpc.serverConf.host + ':' + rpc.serverConf.port + '/jsonrpc',
+			scheme + '://' + rpc.serverConf.host + ':' + rpc.serverConf.port + '/jsonrpc',
 			opts.multicall,
 			opts.func,
 			opts.params,
@@ -44,7 +45,7 @@ JsonRPC.prototype = {
 					return opts.error();
 				}
 
-				var authUrl = 'http://' +
+				var authUrl = scheme + '://' +
 					rpc.serverConf.user +  ":" +
 					rpc.serverConf.pass + "@" +
 					rpc.serverConf.host + ':' +
@@ -80,7 +81,8 @@ var SocketRPC = function(conf) {
 	rpc.serverConf = conf;
 	rpc.initialized = false;
 	rpc.handles = [];
-	rpc.sock = new WebSocket('ws://' + conf.host + ':' + conf.port + '/jsonrpc');
+	var scheme = rpc.serverConf.encryption ? 'wss' : 'ws';
+	rpc.sock = new WebSocket(scheme + '://' + conf.host + ':' + conf.port + '/jsonrpc');
 	rpc.sock.onopen = function() {
 		rpc.initialized = true;
 	};

--- a/js/script.js
+++ b/js/script.js
@@ -24,7 +24,8 @@ var server_conf = {
 	host: 'localhost',
 	port: 6800,
 	user: "",
-	pass: ""
+	pass: "",
+	encryption: false
 };
 
 var ariaConnection = new AriaConnection(server_conf);
@@ -40,6 +41,9 @@ var custom_aria2_connect = function() {
 	clear_dialogs();
         $("#input_host").attr("placeholder", server_conf.host);
         $("#input_port").attr("placeholder", server_conf.port);
+        if(server_conf.encryption) {
+                $("#input_encryption").addClass("active");
+        }
 	modals.change_conf.modal('show');
 };
 var update_server_conf = function() {
@@ -47,6 +51,7 @@ var update_server_conf = function() {
 	var port = $('#input_port').val().trim();
 	server_conf.user = $('#input_user').val().trim();
 	server_conf.pass = $('#input_pass').val().trim();
+	server_conf.encryption = $('#input_encryption').hasClass('active');
 	if(host.length !== 0) {
 		server_conf.host = host;
 	}


### PR DESCRIPTION
This is my initial take to add SSL/TLS encryption.
I added radio-like button on the preference screen to toggle encryption.
I noticed that when encryption turned on and RPC websocket connection is established successfully, but error dialog appears one more time. I think this is because setInterval() function keeps requesting http scheme request to aria2 server. I think it would be good to stop this setInterval() when preference is shown.
