### PR TITLE
Change the way to display file name

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,8 @@
 	}
 	.download_name {
 		overflow: hidden;
-		word-wrap: break-word;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 	@media all and (min-width: 980px) {
 		body {
@@ -81,7 +82,7 @@
 	<!--{{{ active downloads template -->
 	<script type="text/mustache" id="download_active_template">
 		<div class="row download_item download_active_item" data-gid="{{gid}}" data-settingsName={{sett_name}}>
-		<div class="span2 download_name">
+		<div class="span2 download_name" title={{name}}>
 			<b style="font-size: 12px;" class="tmp_name">{{name}}</b>
 		</div>
 		<div class="span6">
@@ -139,7 +140,7 @@
 	<!--{{{ waiting downloads template-->
 	<script type="text/mustache" id="download_waiting_template">
 		<div class="row download_item download_waiting_item" data-gid="{{gid}}" data-settingsName={{sett_name}}>
-		<div class="span2 download_name">
+		<div class="span2 download_name" title={{name}}>
 			<b style="font-size: 12px;" class="tmp_name">{{name}}</b>
 		</div>
 		<div class="span6">
@@ -181,7 +182,7 @@
 	<!--{{{ stopped downloads template-->
 	<script type="text/mustache" id="download_stopped_template">
 		<div class="row download_item download_stopped_item" data-gid="{{gid}}">
-		<div class="span2 download_name">
+		<div class="span2 download_name" title={{name}}>
 			<b style="font-size: 12px;" class="tmp_name">{{settings_name}}</b>
 		</div>
 		<div class="span6">


### PR DESCRIPTION
Replace "word-wrap" with "text-overflow", also adds a title to get the full name.

Before
![before](http://dl.dropbox.com/u/2402301/imgs/github/00-webui-aria2-before.png)

After
![after](http://dl.dropbox.com/u/2402301/imgs/github/01-webui-aria2-after.png)
