### PR TITLE
Display queue order as Aria2 will download.

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -462,11 +462,11 @@ function refreshDownloadTemplates(top_elem, data) {
 			updateDownloadTemplates(elem, ctx);
 		} else {
 			var item = Mustache.render(down_template, ctx);
-			new_items.splice(0, 0, item); //prepend to array using splice (unshift method may not be supported)
+			new_items.push(item);
 		}
 	}
 	if (new_items.length > 0) {
-		$top_elem.prepend(new_items);
+		$top_elem.append(new_items);
 	}
 	$top_elem.children('.hero-unit').remove();
 }


### PR DESCRIPTION
Change to preserve the order items from Aria2.  This shows the correct queue order for waiting downloads.

There is still a problem when pausing & resuming a download which will add the "new" item to the bottom of the waiting queue on the UI even though Aria2 will resume it in the next open slot.  A full page refresh fixes this, but it should really insert in the correct position.  I tried to do this, but it gets tricky and may be better solved with an MVC structure.
