### PR TITLE
Prefixed uint8array() with 'new ' to make everything work again.

### DIFF
--- a/js/services/utils.js
+++ b/js/services/utils.js
@@ -2,7 +2,7 @@ angular.module('webui.services.utils', [])
 .factory('$utils', ['$filter', function(filter) {
   var rnd16 = (function() {
     "use strict";
-    var rndBuffer = Uint8Array(16);
+    var rndBuffer = new Uint8Array(16);
     var rnd16Weak = function() {
       for (var i = 0, r; i < 16; i++) {
         if (!(i % 0x3)) r = Math.random() * 0x100000000 | 0;


### PR DESCRIPTION
Javascript in (at least) Chromium was complaining with "TypeError: DOM object constructor cannot be called as a function".
This corrects it, as shown at end of https://developer.mozilla.org/en-US/docs/Web/JavaScript/Typed_arrays/Uint8Array

(first time on GitHub)
