### PR TITLE
Revert commit 7eec859 ("Do not remove stuff from lists")

### DIFF
--- a/js/ctrls/main.js
+++ b/js/ctrls/main.js
@@ -95,6 +95,17 @@ function(
 				d.followedFrom = null;
 			}
 			rpc.once(method, [d.gid], cb);
+
+			var lists = [scope.active, scope.waiting, scope.stopped], ind = -1, i;
+			for (var i = 0; i < lists.length; ++i) {
+				var list = lists[i];
+				var idx = list.indexOf(d);
+				if (idx < 0) {
+					continue;
+				}
+				list.splice(idx, 1);
+				return;
+			}
 		}, 0);
 	}
 


### PR DESCRIPTION
When removing a download, Angular doesn't update the download list correctly when it receives new data. The list is truncated to the correct number of items, but the item that should have been removed still appears to be in the list (none of the items are shifted up). Noticed this a while ago and it's been really annoying me for a few weeks as I keep deleting the wrong things as a result.

It appears that commit 7eec859 is the cause of this - although with full respect to the author, it seems a completely logically sound decision and I'm not sure why it doesn't work! Someone with a better knowledge of Angular than myself can probably come up with a proper fix for this, but until then, the list item needs to be removed manually.
