### PR TITLE
Add ability to specify per-file options in Add by URI.

### DIFF
--- a/index.html
+++ b/index.html
@@ -646,7 +646,9 @@
         - You can also add multiple uris (mirrors) for the
         *same* file. To do this separate the uris
         by a space. <br>
-        - A URI can be HTTP(S)/FTP/BitTorrent Magnet URI.
+        - Additional options can be specified for individual
+        files, in "--option[=value]" format. <br>
+        - A URI can be HTTP(S)/FTP/BitTorrent Magnet URI. </br>
         - Aria2 will use multiple uris (or mirrors) to boost
         the download speed for that file (download). <br>
         E.g. To add 2 files (downloads) f1.jpg
@@ -656,7 +658,7 @@
         <!-- pre tags print tabs, so do not indent them! -->
 <pre>
 http://ex1.com/f1.jpg http://ex2.com/f1.jpg
-http://ex1.com/f2.mp4 http://ex2.com/f2.mp4
+http://ex1.com/f2.mp4 http://ex2.com/f2.mp4 --out=file2.mp4
 </pre>
       </p>
       <textarea rows="4" style="width: 100%" ng-model="getUris.uris"></textarea>

--- a/js/services/rpc/helpers.js
+++ b/js/services/rpc/helpers.js
@@ -13,8 +13,21 @@ angular.module('webui.services.rpc.helpers', [
     },
     addUris: function(uris, settings, cb) {
       _.each(uris, function(uri) {
+        uri_parsed = [];
+        // parse options passed in the URIs. E.g. http://ex1.com/f1.jpg --out=image.jpg --check-integrity
+        _.each(uri, function(uri_element) {
+          if (uri_element.startsWith('--')) {
+            uri_options = uri_element.split(/--|=(.*)/);
+            if (uri_options.length > 2) {
+              settings[uri_options[2]] = uri_options[3] || 'true';
+            }
+          }
+          else {
+            uri_parsed.push(uri_element);
+          }
+        });
         // passing true to batch all the addUri calls
-        rpc.once('addUri', [uri, settings], cb, true);
+        rpc.once('addUri', [uri_parsed, settings], cb, true);
       });
 
       // now dispatch all addUri syscalls


### PR DESCRIPTION
When downloading files where the filename is not part of the URI, it is impossible to rename them without scrolling endlessly until the "out" setting in Advanced Settings. Even this only enables us to download one URI at a time, since Advanced Settings are global to all files being added.

This PR enables the ability to specify options alongside the URIs, with `--` flags. These will override the ones defined in Advanced Settings.

Example:

```
http://ex1.com/f1.jpg http://ex2.com/f1.jpg
http://ex1.com/f2.mp4 http://ex2.com/f2.mp4 --out=file2.mp4
```

The `out=file2.mp4` setting will be passed only for the relevant file, and not for all as would happen if we modified the out parameter in Advanced Settings (which wouldn't work anyway).
