### PR TITLE
Added missing http-user and place them into $downloadProps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_STORE
 .idea
+.git

--- a/configuration.js
+++ b/configuration.js
@@ -37,7 +37,7 @@ angular
 ])
 .constant('$downloadProps', [ // Similar to starred Quick Access properties but for adding new downloads.
   // go to Advance Download Options when adding a new download to view the list of possible options
-  'pause', 'dir', 'max-connection-per-server'
+  'http-user', 'http-passwd', 'pause', 'dir', 'max-connection-per-server'
 ])
 .constant('$globalTimeout', 1000)  // interval to update the individual downloads
 ;

--- a/js/services/settings/settings.js
+++ b/js/services/settings/settings.js
@@ -292,6 +292,11 @@ angular.module('webui.services.settings', [])
     options: ["true", "false"],
   },
 
+  "http-user": {
+    val: '',
+    desc: "Set HTTP username.",
+  },
+
   "http-passwd": {
     val: '',
     desc: "Set HTTP password.",


### PR DESCRIPTION
Hello @ziahamza,

As title said, I added missing `http-user` option and place them into `$downloadProps` in `configuration.js` to make sure user can set the HTTP authentication easily without accessing so many advanced settings.