### PR TITLE
fix typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1059,7 +1059,7 @@ http://ex1.com/f2.mp4 http://ex2.com/f2.mp4 --out=file2.mp4
               ng-model="connection.conf.directURL"/>
             <p class="help-block">
               {{ 'If supplied, links will be created to enable direct download from the Aria2 server.' | translate }}<br />
-              (( '(Requires an appropriate webserver to be configured.)' | translate }}
+              {{ '(Requires an appropriate webserver to be configured.)' | translate }}
             </p>
           </div>
         </div>


### PR DESCRIPTION
`}}` should be started with `{{`, shouldn't it? 😉