### PR TITLE
Added transport initialization phase.

### DIFF
--- a/js/services/rpc/syscall.js
+++ b/js/services/rpc/syscall.js
@@ -6,6 +6,7 @@ angular
 .factory('$syscall', ['$log', '$jsoncall', '$sockcall', '$alerts',
 function(log, jsonRPC, sockRPC, alerts) {
   return {
+    state: 'none',
     // called to initialize the rpc interface, call everytime configuration changes
     // conf has the following structure:
     // {
@@ -18,8 +19,14 @@ function(log, jsonRPC, sockRPC, alerts) {
     //     pass (string): password for the http authentication if enabled
     //   }
     init: function(conf) {
+      console.log("Syscall is initializing to", conf);
+      this.state = 'initializing';
       jsonRPC.init(conf);
-      sockRPC.init(conf);
+      var syscall = this;
+      sockRPC.init(conf, function() {
+        console.log("Syscall is ready");
+        syscall.state = 'ready';
+      });
     },
 
     // call this to start an rpc call, opts has the following structure:


### PR DESCRIPTION
Websocket transport is not skipped anymore if jsonp is not able to connect.

While changing project to be a part of chrome extension, I faced a problem: json-rpc is not available in chrome extension. Google Chrome does not allow creating custom <script> tags with src other than this extension.

This caused a problem: while websocket was still initializing, rpc already got an error from json-rpc and skipped current transport. Since json-rpc does not work at all, this caused just skipping every possible transport.

Solution: I introduced 'initialization' phase for websocket. While websocket is initializing, rpc service does nothing but waiting. Once websocket is initialized (either opens a connection or gets an error), rpc makes first request. If that request results in error, current transport is skipped, otherwise it is used.