### PR TITLE
Reconnect when token changes on successful connection

### DIFF
--- a/js/services/rpc/rpc.js
+++ b/js/services/rpc/rpc.js
@@ -122,6 +122,7 @@ function(syscall, globalTimeout, alerts, utils, rootScope, uri, authconf, filter
         });
 
         if (failed) {
+          needNewConnection = true;
           alerts.addAlert('<strong>Oh Snap!</strong> Authentication failed while connecting to Aria2 RPC server. Will retry in 10 secs. You might want to confirm your authentication details  by going to Settings > Connection Settings', 'error');
           timeout = setTimeout(update, globalTimeout);
           return;


### PR DESCRIPTION
If the websocket connection succeeds, but the token is wrong, changing
the token in the UI did not succeed (because we are already connected
and nothing was triggering a reconnect attempt with the new config).