### PR TITLE
Fix encoded slash in url

### DIFF
--- a/js/filters/url.js
+++ b/js/filters/url.js
@@ -1,4 +1,4 @@
 angular.module('webui.filters.url', ["webui.services.utils"])
 .filter('encodeURI', function() {
-  return window.encodeURIComponent;
+  return window.encodeURI;
 });


### PR DESCRIPTION
Suppose `some-file` is under `some-folder`.

The direct download url generated should be `http://baseurl/some-folder/some-file`,

not `http://baseurl/some-folder%2Fsome-file`.