### PR TITLE
Defaults to using requested host as Aria2 RPC host

### DIFF
--- a/configuration.js
+++ b/configuration.js
@@ -4,7 +4,7 @@ angular
 .constant('$titlePattern', 'active: {active} - waiting: {waiting} - stopped: {stopped} — {name}')
 .constant('$pageSize', 11)         // number of downloads shown before pagination kicks in
 .constant('$authconf', {           // default authentication configuration, never fill it in case the webui is hosted in public IP as it can be compromised
-  host: 'localhost',
+  host: location.protocol.startsWith('http') ? location.hostname : 'localhost',
   path: '/jsonrpc',
   port: 6800,
   encrypt: false,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+aria2:
+    image: ndthuan/aria2-alpine
+    volumes:
+        - $HOME/Downloads:/downloads
+    ports:
+        - "6800:6800"
+
+httpd:
+    image: busybox
+    volumes:
+        - ./:/usr/html
+    ports:
+        - "80:80"
+    command: /bin/busybox httpd -f -p 80 -h /usr/html


### PR DESCRIPTION
This change which comes together with docker-compose config will make it much easier to set up a local working instance.