### PR TITLE
Report hash verification progress

### DIFF
--- a/index.html
+++ b/index.html
@@ -555,6 +555,72 @@
 
           <!-- }}} -->
         </ul>
+        
+        <ul class="stats pull-left" ng-switch-when="verifing">
+          <!-- {{{ active download statistics -->
+          <li class="label label-warning hidden-phone hidden-tablet">
+            <span title="{{ 'Download status' | translate }}"><span class="fa fa-fw fa-play">&nbsp;</span> {{download.status}}</span>
+          </li>
+
+          <li class="label label-default" ng-class="{'label-active': download.downloadSpeed > 2048, 'label-warning': download.downloadSpeed <= 2048}">
+            <span title="{{ 'Download Speed' | translate }}"><span class="fa fa-fw fa-arrow-circle-o-down">&nbsp;</span> {{download.downloadSpeed | bspeed}}</span>
+          </li>
+
+          <li ng-show="download.bittorrent" class="label label-default hidden-phone" ng-class="{'label-info': download.uploadSpeed > 2048}">
+            <span title="{{ 'Upload Speed' | translate }}"><span class="fa fa-fw fa-arrow-circle-o-up">&nbsp;</span> {{download.uploadSpeed | bspeed}}</span>
+          </li>
+
+          <li class="label label-active">
+            <span title="{{ 'Estimated time' | translate }}"><span class="fa fa-fw fa-clock-o">&nbsp;</span> {{getEta(download) | time}}</span>
+          </li>
+
+          <li class="label label-active hidden-phone">
+            <span title="{{ 'Download Size' | translate }}"><span class="fa fa-fw fa-cloud-download">&nbsp;</span> {{download.fmtTotalLength}}</span>
+          </li>
+
+          <li class="label label-active hidden-phone">
+            <span title="{{ 'Downloaded' | translate }}"><span class="fa fa-fw fa-arrow-circle-o-down">&nbsp;</span> {{download.fmtCompletedLength}}</span>
+          </li>
+
+          <li class="label label-active hidden-phone hidden-tablet">
+            <span title="{{ 'Progress' | translate }}"><span class="fa fa-fw fa-chevron-right">&nbsp;</span> {{getProgress(download)}}%</span>
+          </li>
+
+          <!-- }}} -->
+        </ul>
+
+        <ul class="stats pull-left" ng-switch-when="verifyPending">
+          <!-- {{{ active download statistics -->
+          <li class="label label-warning hidden-phone hidden-tablet">
+            <span title="{{ 'Download status' | translate }}"><span class="fa fa-fw fa-play">&nbsp;</span> {{download.status}}</span>
+          </li>
+
+          <li class="label label-default" ng-class="{'label-active': download.downloadSpeed > 2048, 'label-warning': download.downloadSpeed <= 2048}">
+            <span title="{{ 'Download Speed' | translate }}"><span class="fa fa-fw fa-arrow-circle-o-down">&nbsp;</span> {{download.downloadSpeed | bspeed}}</span>
+          </li>
+
+          <li ng-show="download.bittorrent" class="label label-default hidden-phone" ng-class="{'label-info': download.uploadSpeed > 2048}">
+            <span title="{{ 'Upload Speed' | translate }}"><span class="fa fa-fw fa-arrow-circle-o-up">&nbsp;</span> {{download.uploadSpeed | bspeed}}</span>
+          </li>
+
+          <li class="label label-active">
+            <span title="{{ 'Estimated time' | translate }}"><span class="fa fa-fw fa-clock-o">&nbsp;</span> {{getEta(download) | time}}</span>
+          </li>
+
+          <li class="label label-active hidden-phone">
+            <span title="{{ 'Download Size' | translate }}"><span class="fa fa-fw fa-cloud-download">&nbsp;</span> {{download.fmtTotalLength}}</span>
+          </li>
+
+          <li class="label label-active hidden-phone">
+            <span title="{{ 'Downloaded' | translate }}"><span class="fa fa-fw fa-arrow-circle-o-down">&nbsp;</span> {{download.fmtCompletedLength}}</span>
+          </li>
+
+          <li class="label label-active hidden-phone hidden-tablet">
+            <span title="{{ 'Progress' | translate }}"><span class="fa fa-fw fa-chevron-right">&nbsp;</span> {{getProgress(download)}}%</span>
+          </li>
+
+          <!-- }}} -->
+        </ul>
 
         <ul class="stats pull-left" ng-switch-when="paused">
           <!-- {{{ paused download statistics -->

--- a/js/ctrls/main.js
+++ b/js/ctrls/main.js
@@ -318,7 +318,7 @@ function(
 		}
 		else if (scope.filterSpeed) {
 			downloads = _.filter(scope.active, function (e) {
-				return +e.uploadSpeed || +e.downloadSpeed;
+				return +e.uploadSpeed || +e.downloadSpeed;
 			});
 		}
 		if (scope.filterWaiting) {
@@ -398,6 +398,10 @@ function(
 				animCollapsed: true,
 				files: [],
 			};
+			if (d.verifiedLength)
+				ctx.verifiedLength = d.verifiedLength;
+			if (d.verifyIntegrityPending)
+				ctx.verifyIntegrityPending = d.verifyIntegrityPending;
 		}
 		else {
 		    if (ctx.gid !== d.gid)
@@ -426,6 +430,16 @@ function(
 			if (ctx.completedLength !== d.completedLength) {
 				ctx.completedLength = d.completedLength;
 				ctx.fmtCompletedLength = utils.fmtsize(d.completedLength);
+			}
+			if (!d.verifiedLength) {
+				delete ctx.verifiedLength
+			} else if (ctx.verifiedLength !== d.verifiedLength) {
+				ctx.verifiedLength = d.verifiedLength;
+			}
+			if (!d.verifyIntegrityPending) {
+				delete ctx.verifyIntegrityPending
+			} else if (ctx.verifyIntegrityPending !== d.verifyIntegrityPending) {
+				ctx.verifyIntegrityPending = d.verifyIntegrityPending;
 			}
 			if (ctx.uploadLength !== d.uploadength) {
 				ctx.uploadLength = d.uploadlength;
@@ -520,7 +534,10 @@ function(
 			case "removed":
 				return "progress-bar-warning";
 			case "active":
-				return "active";
+				if (d.verifyIntegrityPending || d.verifiedLength)
+					return "progress-bar-warning"
+				else
+					return "active";
 			case "complete":
 				return "progress-bar-success";
 			default:
@@ -530,7 +547,11 @@ function(
 
 	// gets the progress in percentages
 	scope.getProgress = function(d) {
-		var percentage = (d.completedLength / d.totalLength)*100 || 0;
+		var percentage = 0
+		if (d.verifiedLength)
+			percentage = (d.verifiedLength / d.totalLength) * 100 || 0;
+		else
+			percentage = (d.completedLength / d.totalLength) * 100 || 0;
 		percentage = percentage.toFixed(2);
 		if(!percentage) percentage = 0;
 

--- a/js/ctrls/main.js
+++ b/js/ctrls/main.js
@@ -398,16 +398,24 @@ function(
 				animCollapsed: true,
 				files: [],
 			};
-			if (d.verifiedLength)
+			if (d.verifiedLength) {
 				ctx.verifiedLength = d.verifiedLength;
-			if (d.verifyIntegrityPending)
+				ctx.status = "verifing";
+			}
+			if (d.verifyIntegrityPending) {
 				ctx.verifyIntegrityPending = d.verifyIntegrityPending;
+				ctx.status = "verifyPending";
+			}
 		}
 		else {
 		    if (ctx.gid !== d.gid)
 		        ctx.files = [];
 			ctx.dir = d.dir;
 			ctx.status = d.status;
+			if(d.verifiedLength)
+				ctx.status = "verifing";
+			if(d.verifyIntegrityPending)
+				ctx.status = "verifyPending"
 			ctx.errorCode = d.errorCode;
 			ctx.gid = d.gid;
 			ctx.followedBy = (d.followedBy && d.followedBy.length == 1
@@ -534,10 +542,9 @@ function(
 			case "removed":
 				return "progress-bar-warning";
 			case "active":
-				if (d.verifyIntegrityPending || d.verifiedLength)
-					return "progress-bar-warning"
-				else
-					return "active";
+				return "active";
+			case "verifing":
+				return "progress-bar-warning";
 			case "complete":
 				return "progress-bar-success";
 			default:


### PR DESCRIPTION
Resolves #210 

This will show the progress of hash verification were previously the UI would only display the download as active with no progress until hash verification completed. I don't think this is a mergable state. I would still like to add in display that the remaining `active` but non-downloading items are queued. I'm just looking for feedback that this is appropriate and mergable or any changes you would like to see.