### PR TITLE
Add dockerfile for raspberry build

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Well, you need aria2. And a web browser (if that even counts!)
 
 Docker support
 ==============
+There is two Dockerfile in this project, one is a common Dockerfile, which can be use for **testing purpose**.<br>
+The second is a **production ready** Dockerfile for raspberry and other ARM plateforms.
+
+### For testing purpose
+
 You can also try or use webui-aria2 in your LAN inside a Docker sandbox.
 
 Build the image
@@ -50,6 +55,28 @@ sudo docker run -v /Downloads:/data -p 6800:6800 -p 9100:8080 --name="webui-aria
 ````
 
 `/Downloads` is the directory in the host where you want to keep the downloaded files
+
+### Production ready (ARM platform)
+
+This image contains both aria2 and webui-aria2.
+
+Build it
+```
+docker build -f rpi-Dockerfile -t yourname/webui-aria2 .
+```
+Prepare the host volume:
+This image required few file to be mounted in the container's `/data` folder.
+```
+.aria2/session.txt  (empty file)
+.aria2/aria2.log    (empty file)
+.aria2/aria2.conf   (aria2 configuration file, not webui-aria2 conf)
+./downloads/        (where the downloaded files goes)
+```
+
+Run it
+```
+docker run -d -v /home/<USER>/data/aria2:/data -p 6800:6800 -p 9100:8080 --name="webui-aria2" yourname/webui-aria2
+```
 
 Support
 =======

--- a/rpi-Dockerfile
+++ b/rpi-Dockerfile
@@ -1,0 +1,41 @@
+FROM resin/rpi-raspbian
+
+# less priviledge user, the id should map the user the downloaded files belongs to
+RUN groupadd -r aria && useradd -r -g aria aria -u 1000
+
+# webui + aria2
+RUN apt-get update \
+        && apt-get install -y aria2 busybox curl git \
+        && rm -rf /var/lib/apt/lists/*
+
+ADD . /webui-aria2
+
+# gosu install latest
+RUN GITHUB_REPO="https://github.com/tianon/gosu" \
+  && LATEST=`curl -s  $GITHUB_REPO"/releases/latest" | grep -Eo "[0-9].[0-9]*"` \
+  && curl -L $GITHUB_REPO"/releases/download/"$LATEST"/gosu-armhf" > /usr/local/bin/gosu \
+  && chmod +x /usr/local/bin/gosu
+
+# goland install (compile source code for ARM since no version are currently available)
+RUN curl -L "https://storage.googleapis.com/golang/go1.6.1.linux-armv6l.tar.gz" > go.tar.gz \
+  && tar -xzf go.tar.gz -C /usr/local \
+  && export GOROOT="/usr/local/go" && export GOPATH=`pwd` \
+  && $GOROOT/bin/go get github.com/mattn/goreman && $GOROOT/bin/go build -o /usr/local/bin/goreman github.com/mattn/goreman \
+  && apt-get remove purge --auto-remove git \
+  && rm go.tar.gz && rm -rf $GOROOT && rm -rf $GOPATH/src && rm -rf $GOPATH/pkg \
+  && unset GOROOT && unset GOPATH
+
+# goreman setup
+RUN echo "web: gosu aria /bin/busybox httpd -f -p 8080 -h /webui-aria2\nbackend: gosu aria /usr/bin/aria2c --conf-path=/data/.aria2/aria2.conf" > Procfile
+
+# aria2 downloads directory
+VOLUME /data
+
+# aria2 RPC port, map as-is or reconfigure webui
+EXPOSE 6800/tcp
+
+# webui static content web server, map wherever is convenient
+EXPOSE 8080/tcp
+
+CMD ["start"]
+ENTRYPOINT ["/usr/local/bin/goreman"]

--- a/rpi-Dockerfile
+++ b/rpi-Dockerfile
@@ -21,7 +21,7 @@ RUN curl -L "https://storage.googleapis.com/golang/go1.6.1.linux-armv6l.tar.gz" 
   && tar -xzf go.tar.gz -C /usr/local \
   && export GOROOT="/usr/local/go" && export GOPATH=`pwd` \
   && $GOROOT/bin/go get github.com/mattn/goreman && $GOROOT/bin/go build -o /usr/local/bin/goreman github.com/mattn/goreman \
-  && apt-get remove purge --auto-remove git \
+  && apt-get remove --purge --auto-remove git \
   && rm go.tar.gz && rm -rf $GOROOT && rm -rf $GOPATH/src && rm -rf $GOPATH/pkg \
   && unset GOROOT && unset GOPATH
 


### PR DESCRIPTION
Add a Dockerfile for Raspberry (ARM architecture).

This Docker image does not only allow to publish a dev mode.
It deploy a fully functionnal aria2 and webui-aria2.

Few files are needed to be mounted into `/data` :
 - `/data/.aria2/session.txt` (empty file, but need to be present)
 - `/data/.aria2/aria2.log` (empty file, but need to be present)
 - `/data/.aria2/aria2.conf` (aria2 configuration file, not webui-aria2 conf)