### PR TITLE
Make getUris dialog more compact

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
   <script src="js/directives/chunkbar.js"></script>
   <script src="js/directives/dgraph.js"></script>
   <script src="js/directives/fselect.js"></script>
+  <script src="js/directives/textarea.js"></script>
 
   <script src="js/filters/bytes.js"></script>
   <script src="js/filters/url.js"></script>
@@ -811,22 +812,17 @@
     {{ '- You can add multiple downloads (files) at the same time by putting URIs for each file on a separate line.' | translate }}<br />
     {{ '- You can also add multiple URIs (mirrors) for the *same* file. To do this, separate the URIs by a space.' | translate }}<br />
     {{ '- A URI can be HTTP(S)/FTP/BitTorrent-Magnet.' | translate }}</br>
-    {{ 'E.g. to add 2 files (downloads) f1.jpg and f2.mp4 with 2 URIs (mirrors) each, add URIs as follows' | translate }}:<br />
-        <!-- pre tags print tabs, so do not indent them! -->
-<pre>
-http://ex1.com/f1.jpg http://ex2.com/f1.jpg
-http://ex1.com/f2.mp4 http://ex2.com/f2.mp4 --out=file2.mp4
-</pre>
       </p>
-      <textarea rows="4" style="width: 100%" ng-model="getUris.uris" autofocus></textarea>
-
+      <textarea rows="4" style="width: 100%" ng-model="getUris.uris" autofocus placeholder="http://mirror1.com/f1.jpg http://mirror2.com/f1.jpg\nhttp://mirror1.com/f2.mp4 http://mirror2.com/f2.mp4 --out=file2.mp4"></textarea>
       <br /><br />
 
         <div>
-          <div class="modal-advanced-title">
+          <div ng-click="getUris.downloadSettingsCollapsed = !getUris.downloadSettingsCollapsed" class="modal-advanced-title">
             {{ 'Download settings' | translate }}
+            <i ng-hide="!getUris.downloadSettingsCollapsed" class="fa fa-fw fa-caret-right"></i>
+            <i ng-hide="getUris.downloadSettingsCollapsed" class="fa fa-fw fa-caret-down"></i>
           </div>
-          <div class="form-horizontal modal-advanced-options">
+          <div collapse="getUris.downloadSettingsCollapsed" class="form-horizontal modal-advanced-options">
             <div class="form-group" ng-repeat="(name, set) in getUris.settings">
               <label class="col-sm-3 control-label">{{name}}</label>
 
@@ -840,12 +836,12 @@ http://ex1.com/f2.mp4 http://ex2.com/f2.mp4 --out=file2.mp4
           </div>
 
           <br />
-          <div ng-click="getUris.collapsed = !getUris.collapsed" class="modal-advanced-title">
+          <div ng-click="getUris.advancedSettingsCollapsed = !getUris.advancedSettingsCollapsed" class="modal-advanced-title">
             {{ 'Advanced settings' | translate }}
-            <i ng-hide="!getUris.collapsed" class="fa fa-fw fa-caret-right"></i>
-            <i ng-hide="getUris.collapsed" class="fa fa-fw fa-caret-down"></i>
+            <i ng-hide="!getUris.advancedSettingsCollapsed" class="fa fa-fw fa-caret-right"></i>
+            <i ng-hide="getUris.advancedSettingsCollapsed" class="fa fa-fw fa-caret-down"></i>
           </div>
-          <div collapse="getUris.collapsed" class="form-horizontal modal-advanced-options">
+          <div collapse="getUris.advancedSettingsCollapsed" class="form-horizontal modal-advanced-options">
             <div class="form-group" ng-repeat="(name, set) in getUris.fsettings">
               <p class="col-sm-offset-3 col-sm-9 help-block controls">{{set.desc}}</p>
 
@@ -860,11 +856,11 @@ http://ex1.com/f2.mp4 http://ex2.com/f2.mp4 --out=file2.mp4
           </div>
         </div>
     </fieldset>
+    <div class="modal-footer">
+      <button type="button" class="btn btn-default" ng-click="$dismiss()">{{ 'Cancel' | translate }}</button>
+      <button class="btn btn-default btn-primary" ng-click="$close()">{{ 'Start' | translate }}</button>
+    </div>
   </form>
-  <div class="modal-footer">
-    <button class="btn btn-default" ng-click="$dismiss()">{{ 'Cancel' | translate }}</button>
-    <button class="btn btn-default btn-primary" ng-click="$close()">{{ 'Start' | translate }}</button>
-  </div>
 </script>
 <!-- }}} -->
 

--- a/js/ctrls/modal.js
+++ b/js/ctrls/modal.js
@@ -37,7 +37,8 @@ angular
     open: function(cb) {
       var self = this;
       this.uris = "";
-      this.collapsed = true;
+      this.downloadSettingsCollapsed = true;
+      this.advancedSettingsCollapsed = true;
       this.settings = {};
       this.fsettings = _.cloneDeep(fsettings);
       this.cb = cb;

--- a/js/directives/textarea.js
+++ b/js/directives/textarea.js
@@ -1,0 +1,16 @@
+webui.directive("textarea", function() {
+  return {
+    restrict: "E",
+    link: function(scope, element) {
+      element.attr(
+        "placeholder",
+        element.attr("placeholder").replace(/\\n/g, "\n")
+      ).bind("keydown keypress", function(event) {
+        if (event.ctrlKey && event.which === 13) {
+          event.preventDefault();
+          scope.$close();
+        }
+      });
+    }
+  };
+});

--- a/js/translate/de_DE.js
+++ b/js/translate/de_DE.js
@@ -58,8 +58,6 @@ translations.de_DE = {
     '- You can also add multiple URIs (mirrors) for the *same* file. To do this, separate the URIs by a space.':
         '- Es können auch mehrere URIs (Spiegelserver) für *dieselbe* Datei durch Leerzeichen getrennt angegeben werden.',
     '- A URI can be HTTP(S)/FTP/BitTorrent-Magnet.': '- Eine URI kann folgende Protokolle besitzen: HTTP(S)/FTP/BitTorrent-Magnet.',
-    'E.g. to add 2 files (downloads) f1.jpg and f2.mp4 with 2 URIs (mirrors) each, add URIs as follows':
-        'Um z.B. 2 Dateien (Downloads) f1.jpg und f2.mp4 mit jeweis einem zweiten Spiegelserver herunterzuladen, kann folgendes angegeben werden',
     'Download settings': 'Download Einstellungen',
     'Advanced settings': 'Erweiterte Einstellungen',
     'Cancel': 'Abbrechen',

--- a/js/translate/en_US.js
+++ b/js/translate/en_US.js
@@ -62,8 +62,6 @@ translations.en_US = {
     '- You can also add multiple URIs (mirrors) for the *same* file. To do this, separate the URIs by a space.':
         '- You can also add multiple URIs (mirrors) for the *same* file. To do this, separate the URIs by a space.',
     '- A URI can be HTTP(S)/FTP/BitTorrent-Magnet.': '- A URI can be HTTP(S)/FTP/BitTorrent-Magnet.',
-    'E.g. to add 2 files (downloads) f1.jpg and f2.mp4 with 2 URIs (mirrors) each, add URIs as follows':
-        'E.g. to add 2 files (downloads) f1.jpg and f2.mp4 with 2 URIs (mirrors) each, add URIs as follows',
     'Download settings': 'Download settings',
     'Advanced settings': 'Advanced settings',
     'Cancel': 'Cancel',

--- a/js/translate/es_ES.js
+++ b/js/translate/es_ES.js
@@ -73,8 +73,6 @@ translations.es_ES = {  // replace en_US to ll_CC, examples: zh_CN, de_AT.
     '- You can also add multiple URIs (mirrors) for the *same* file. To do this, separate the URIs by a space.':
         'Puede añadir URIs de espejo para *el mismo* archivo. Separe cada URI con un espacio.',
     '- A URI can be HTTP(S)/FTP/BitTorrent-Magnet.': 'Una URI puede ser HTTP(S), FTP, BitTorrent o Magnet.',
-    'E.g. to add 2 files (downloads) f1.jpg and f2.mp4 with 2 URIs (mirrors) each, add URIs as follows':
-        'Ej: Para añadir dos descargas f1.jpg y f2.mp4 con dos URIs espejo cada una, añada las URIs así',
     'Download settings': 'Ajustes de Descargas',
     'Advanced settings': 'Ajustes Avanzados',
     'Cancel': 'Cancelar',

--- a/js/translate/fr_FR.js
+++ b/js/translate/fr_FR.js
@@ -58,8 +58,6 @@ translations.fr_FR = {
     '- You can also add multiple URIs (mirrors) for the *same* file. To do this, separate the URIs by a space.':
         'Vous pouvez aussi ajouter plusieurs URIs (mirroirs) pour le *même* fichier. Pour ce faire, séparez les URIs par un espace.',
     '- A URI can be HTTP(S)/FTP/BitTorrent-Magnet.': 'Une URI peut être HTTP(S)/FTP/BitTorrent-Magnet.',
-    'E.g. to add 2 files (downloads) f1.jpg and f2.mp4 with 2 URIs (mirrors) each, add URIs as follows':
-        'E.g. pour ajouter 2 fichiers (téléchargements) f1.jpg et f2.mp4 avec 2 URIs (mirroirs) chacuns, ajoutez les URIs ainsi',
     'Download settings': 'Paramètres de téléchargement',
     'Advanced settings': 'Paramètres avancés',
     'Cancel': 'Annuler',

--- a/js/translate/it_IT.js
+++ b/js/translate/it_IT.js
@@ -58,8 +58,6 @@ translations.it_IT = {
     '- You can also add multiple URIs (mirrors) for the *same* file. To do this, separate the URIs by a space.':
         '- Puoi anche aggiungere più URI di download(mirror) per uno *stesso* file separando i vari mirror da uno spazio.',
     '- A URI can be HTTP(S)/FTP/BitTorrent-Magnet.': '- Un URI può essere un indirizzo HTTP(S)/FTP o un BitTorrent Magnet link.',
-    'E.g. to add 2 files (downloads) f1.jpg and f2.mp4 with 2 URIs (mirrors) each, add URIs as follows':
-        'Ad esempio, per scaricare 2 files f1.jpg and f2.mp4 con 2 URIs (mirrors) ciascuno, aggiungi gli indirizzi così',
     'Download settings': 'Impostazioni download',
     'Advanced settings': 'Impostazioni avanzate',
     'Cancel': 'Cancella',

--- a/js/translate/nl_NL.js
+++ b/js/translate/nl_NL.js
@@ -58,8 +58,6 @@ translations.nl_NL = {
     '- You can also add multiple URIs (mirrors) for the *same* file. To do this, separate the URIs by a space.':
         '- Je kunt ook meerdere URIs (mirrors) voor *hetzelfde* bestand toevoegen. Scheidt hiervoor de URIs met een spatie.',
     '- A URI can be HTTP(S)/FTP/BitTorrent-Magnet.': '- Een URI kan HTTP(S)/FTP/BitTorrent-Magnet zijn.',
-    'E.g. to add 2 files (downloads) f1.jpg and f2.mp4 with 2 URIs (mirrors) each, add URIs as follows':
-        'Bijvoorbeeld, voor het toevoegen van 2 bestanden (downloads) f1.jpg en f2.mp4 met 2 URIs (mirrors) elk, voeg de URIs op deze manier:',
     'Download settings': 'Download instellingen',
     'Advanced settings': 'Geavanceerde instellingen',
     'Cancel': 'Annuleren',

--- a/js/translate/pl_PL.js
+++ b/js/translate/pl_PL.js
@@ -56,7 +56,6 @@ translations.pl_PL = {
 	'- You can add multiple downloads (files) at the same time by putting URIs for each file on a separate line.': '- Możesz dodać wiele pobrań (plików) w tym samym czasie przez wprowadzenie URI dla każdego w oddzielnej linii.',
 	'- You can also add multiple URIs (mirrors) for the *same* file. To do this, separate the URIs by a space.': '- Możesz także dodać wiele URI (luster) dla tego *samego* pliku. Zrób to, poprzez oddzielenie URI od siebie spacją.',
     '- A URI can be HTTP(S)/FTP/BitTorrent-Magnet.': '- URI może być HTTP(S)/FTP/BitTorrent-Magnet.',
-    'E.g. to add 2 files (downloads) f1.jpg and f2.mp4 with 2 URIs (mirrors) each, add URIs as follows': 'Np. aby dodać 2 pliki (pobieranie) f1.jpg i f2.mp4 z 2 URI (lustrami) każdy, dodaj URI jak poniżej',
 	'Download settings': 'Ustawienia pobierania',
     'Advanced settings': 'Zaawansowane ustawienia',
     'Cancel': 'Anuluj',

--- a/js/translate/ru_RU.js
+++ b/js/translate/ru_RU.js
@@ -58,8 +58,6 @@ translations.ru_RU = {
     '- You can also add multiple URIs (mirrors) for the *same* file. To do this, separate the URIs by a space.':
         '- Можно также добавить несколько URL-адресов (зеркал) для *одного* файла. Для этого отделите URL-адреса пробелом.',
     '- A URI can be HTTP(S)/FTP/BitTorrent-Magnet.': '- URL-адрес может быть HTTP(S)/FTP/BitTorrent-Magnet.',
-    'E.g. to add 2 files (downloads) f1.jpg and f2.mp4 with 2 URIs (mirrors) each, add URIs as follows':
-        'Например для добавления 2 файлов (загрузок) f1.jpg и f2.mp4 с 2 URL-адресов (зеркал), добавьте URL-адреса следующим образом',
     'Download settings': 'Настройки загрузки',
     'Advanced settings': 'Расширенные настройки',
     'Cancel': 'Отмена',

--- a/js/translate/template.js
+++ b/js/translate/template.js
@@ -77,8 +77,6 @@ translations.en_US = {  // replace en_US to ll_CC, examples: zh_CN, de_AT.
     '- You can also add multiple URIs (mirrors) for the *same* file. To do this, separate the URIs by a space.':
         '',
     '- A URI can be HTTP(S)/FTP/BitTorrent-Magnet.': '',
-    'E.g. to add 2 files (downloads) f1.jpg and f2.mp4 with 2 URIs (mirrors) each, add URIs as follows':
-        '',
     'Download settings': '',
     'Advanced settings': '',
     'Cancel': '',

--- a/js/translate/th_TH.js
+++ b/js/translate/th_TH.js
@@ -58,8 +58,6 @@ translations.th_TH = {
     '- You can also add multiple URIs (mirrors) for the *same* file. To do this, separate the URIs by a space.':
         '',
     '- A URI can be HTTP(S)/FTP/BitTorrent-Magnet.': '',
-    'E.g. to add 2 files (downloads) f1.jpg and f2.mp4 with 2 URIs (mirrors) each, add URIs as follows':
-        '',
     'Download settings': 'ตั้งค่าการดาวน์โหลด',
     'Advanced settings': 'ตั้งค่าขั้นสูง',
     'Cancel': 'ยกเลิก',

--- a/js/translate/tr_TR.js
+++ b/js/translate/tr_TR.js
@@ -58,8 +58,6 @@ translations.tr_TR = {
     '- You can also add multiple URIs (mirrors) for the *same* file. To do this, separate the URIs by a space.':
         '- Aynı dosyalar için birden fazla URI (ayna) da ekleyebilirsiniz. Bunu yapmak için URIları bir boşlukla ayırın.',
     '- A URI can be HTTP(S)/FTP/BitTorrent-Magnet.': '- Bir URI, HTTP(S)/FTP/BitTorrent-Magnet olabilir.',
-    'E.g. to add 2 files (downloads) f1.jpg and f2.mp4 with 2 URIs (mirrors) each, add URIs as follows':
-        'Örneğin. 2 dosya (indir) f1.jpg ve f2.mp4ü 2 URIla (aynalar) ekleyin, URIları aşağıdaki gibi ekleyin',
     'Download settings': 'İndirme ayarları',
     'Advanced settings': 'Gelişmiş Ayarlar',
     'Cancel': 'İptal et',

--- a/js/translate/zh_CN.js
+++ b/js/translate/zh_CN.js
@@ -63,8 +63,6 @@ translations.zh_CN = {
     '- You can also add multiple URIs (mirrors) for the *same* file. To do this, separate the URIs by a space.':
         '- 你也可以给同一个下载任务添加多个镜像链接，写在一行并用空格分隔每条链接；',
     '- A URI can be HTTP(S)/FTP/BitTorrent-Magnet.': '- 链接可以是 HTTP(S)、FTP 和磁力链接。',
-    'E.g. to add 2 files (downloads) f1.jpg and f2.mp4 with 2 URIs (mirrors) each, add URIs as follows':
-        '例如：添加 2 个下载任务 f1.jpg 和 f2.mp4（它们都有2个镜像链接），添加方式如下',
     'Download settings': '下载设置',
     'Advanced settings': '高级设置',
     'Cancel': '取消',

--- a/js/translate/zh_TW.js
+++ b/js/translate/zh_TW.js
@@ -63,8 +63,6 @@ translations.zh_TW = {
     '- You can also add multiple URIs (mirrors) for the *same* file. To do this, separate the URIs by a space.':
         '- 你也可以給同一個下載任務新增多個映象連結，寫在一行並用空格分隔每條連結；',
     '- A URI can be HTTP(S)/FTP/BitTorrent-Magnet.': '- 連結可以是 HTTP(S)、FTP 和磁力連結。',
-    'E.g. to add 2 files (downloads) f1.jpg and f2.mp4 with 2 URIs (mirrors) each, add URIs as follows':
-        '例如：新增 2 個下載任務 f1.jpg 和 f2.mp4（它們都有2個映象連結），新增方式如下',
     'Download settings': '下載設定',
     'Advanced settings': '高階設定',
     'Cancel': '取消',


### PR DESCRIPTION
This patch resolves #295 by making the Download Settings fieldset collapsed by default and moving the examples of URIs in textarea into the placeholder of textarea itself.

![compact-get-uris](https://cloud.githubusercontent.com/assets/59683/21752886/60df063e-d595-11e6-82dd-efe25310cf45.png)

It also allows form submission when textarea is focused by pressing `Ctrl`+`Enter`.