### PR TITLE
Update Dockerfile to handle zip releases from goreman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN groupadd -r dummy && useradd -r -g dummy dummy -u 1000
 
 # webui + aria2
 RUN apt-get update \
-	&& apt-get install -y aria2 busybox curl \
+	&& apt-get install -y aria2 busybox curl unzip \
 	&& rm -rf /var/lib/apt/lists/*
 
 ADD . /webui-aria2
@@ -19,8 +19,8 @@ RUN GITHUB_REPO="https://github.com/tianon/gosu" \
 # goreman supervisor install latest
 RUN GITHUB_REPO="https://github.com/mattn/goreman" \
   && LATEST=`curl -s  $GITHUB_REPO"/releases/latest" | grep -Eo "v[0-9]*.[0-9]*.[0-9]*"` \
-  && curl -L $GITHUB_REPO"/releases/download/"$LATEST"/goreman_linux_amd64.tar.gz" > goreman.tar.gz \
-  && tar -xvzf goreman.tar.gz && mv /goreman_linux_amd64/goreman /usr/local/bin/goreman && rm -R goreman*
+  && curl -L $GITHUB_REPO"/releases/download/"$LATEST"/goreman_linux_amd64.zip" > goreman.zip \
+  && unzip goreman.zip && mv /goreman /usr/local/bin/goreman && rm -R goreman*
 
 # goreman setup
 RUN echo "web: gosu dummy /bin/busybox httpd -f -p 8080 -h /webui-aria2\nbackend: gosu dummy /usr/bin/aria2c --enable-rpc --rpc-listen-all --dir=/data" > Procfile


### PR DESCRIPTION
Latest release on https://github.com/mattn/goreman/releases are all in zip and breaks the Dockerfile.