### PR TITLE
add folder structure to select files in select-file option

### DIFF
--- a/css/modals.css
+++ b/css/modals.css
@@ -42,3 +42,7 @@
 .selectFiles div .controls {
   margin-left: 30px;
 }
+
+.selectFiles div.recursivedir {
+  width: 100%;
+}

--- a/css/modals.css
+++ b/css/modals.css
@@ -34,11 +34,11 @@
   width: 80px;
 }
 
-.selectFiles > div > .control-label {
+.selectFiles div .control-label {
   font-weight: normal;
   margin-left: 30px;
 }
 
-.selectFiles > div > .controls {
+.selectFiles div .controls {
   margin-left: 30px;
 }

--- a/index.html
+++ b/index.html
@@ -1040,7 +1040,7 @@
       <!--click to toggle show the subfolders and files-->
       <div class="checkbox" data-ng-click="folder.show=!folder.show">
         <!-- The value of indeterminate="" can be bound to any angular expression -->
-        <input type="checkbox" ng-model="folder.selected" data-ng-click="$event.stopPropagation()" indeterminate="folder.indeterminate" monitor/>{{folderName}}
+        <input type="checkbox" data-ng-model="folder.selected" data-ng-click="$event.stopPropagation()" indeterminate/>{{folderName}}
         <span ng-show="!folder.show" class="control-label">{{ 'click the text to expand the folder' | translate }}</span>
         <span ng-show="folder.show" class="control-label">{{ 'click the text to collapse the folder' | translate }}</span>
       </div>
@@ -1055,7 +1055,7 @@
 
     <div class="controls">
       <label class="checkbox">
-        <input type="checkbox" ng-model="file.selected" monitor/>{{file.relpath}}
+        <input type="checkbox" data-ng-model="file.selected" indeterminate="false"/>{{file.relpath}}
       </label>
     </div>
     <br/>

--- a/index.html
+++ b/index.html
@@ -1031,7 +1031,7 @@
 </script>
 <!-- }}} -->
 
-  <!-- {{{ select files checkbox modal -->
+<!-- {{{ select files checkbox modal -->
 <script type="text/ng-template" id="selectFilesCheckBox.html">
   <div ng-repeat="(folderName,folder) in files.dirs">
     <!--recursive folder-->
@@ -1040,7 +1040,7 @@
       <!--click to toggle show the subfolders and files-->
       <div class="checkbox" data-ng-click="folder.show=!folder.show">
         <!-- The value of indeterminate="" can be bound to any angular expression -->
-        <input type="checkbox" ng-model="folder.selected" data-ng-click="$event.stopPropagation()" indeterminate="true"/>{{folderName}}
+        <input type="checkbox" ng-model="folder.selected" data-ng-click="$event.stopPropagation()" indeterminate="folder.indeterminate" monitor/>{{folderName}}
         <span ng-show="!folder.show" class="control-label">{{ 'click the text to expand the folder' | translate }}</span>
         <span ng-show="folder.show" class="control-label">{{ 'click the text to collapse the folder' | translate }}</span>
       </div>
@@ -1055,7 +1055,7 @@
 
     <div class="controls">
       <label class="checkbox">
-        <input type="checkbox" ng-model="file.selected"/>{{file.relpath}}
+        <input type="checkbox" ng-model="file.selected" monitor/>{{file.relpath}}
       </label>
     </div>
     <br/>

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
   <script src="js/libs/jquery-2.2.4.min.js"></script>
   <script src="js/libs/lodash-4.17.3.min.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.6.5/angular.js"></script>
+  <script src="js/libs/angular.min.js"></script>
 
   <script src="js/libs/angularui-bootstrap-tpls.min.js"></script>
   <script src="js/libs/bootstrap-filestyle.js"></script>
@@ -1044,7 +1044,7 @@
         <span ng-show="!folder.show" class="control-label">{{ 'click the text to expand the folder' | translate }}</span>
         <span ng-show="folder.show" class="control-label">{{ 'click the text to collapse the folder' | translate }}</span>
       </div>
-      <div ng-show="folder.show" class="form-group selectFiles" ng-include="'selectFilesCheckBox.html'" ng-init="files=folder">
+      <div ng-show="folder.show" class="form-group selectFiles recursivedir" ng-include="'selectFilesCheckBox.html'" ng-init="files=folder">
       </div>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
   <script src="js/libs/jquery-2.2.4.min.js"></script>
   <script src="js/libs/lodash-4.17.3.min.js"></script>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.6.5/angular.js"></script>
+  <script src="js/libs/angular.min.js"></script>
 
   <script src="js/libs/angularui-bootstrap-tpls.min.js"></script>
   <script src="js/libs/bootstrap-filestyle.js"></script>

--- a/index.html
+++ b/index.html
@@ -1030,6 +1030,36 @@
 </script>
 <!-- }}} -->
 
+  <!-- {{{ select files checkbox modal -->
+<script type="text/ng-template" id="selectFilesCheckBox.html">
+  <div ng-repeat="(folder,file) in files">
+    <!--is's a folder-->
+    <div ng-if="!file.index || file.index.toString().indexOf('object') >= 0">
+      <div class="controls">
+        <label class="checkbox">
+          <input type="checkbox"/>{{folder}}
+        </label>
+        <div class="form-group selectFiles" ng-include="'selectFilesCheckBox.html'" ng-init="files=file">
+        </div>
+      </div>
+    </div>
+
+    <!--is's a file-->
+    <div ng-if="file.index && file.index.toString().indexOf('object') < 0">
+      <label class="control-label">{{ 'Select to download' | translate }}</label>
+
+      <div class="controls">
+        <label class="checkbox">
+          <input type="checkbox" ng-model="file.selected"/>{{file.relpath}}
+        </label>
+      </div>
+      <br/>
+      <br/>
+    </div>
+  </div>
+</script>
+<!-- }}} -->
+
 <!-- {{{ select file modal -->
 <script type="text/ng-template" id="selectFiles.html">
   <div class="modal-header">
@@ -1039,17 +1069,7 @@
 
   <form class="form-horizontal modal-body">
     <fieldset>
-      <div class="form-group selectFiles">
-        <div ng-repeat="file in selectFiles.files">
-          <label class="control-label">{{ 'Select to download' | translate }}</label>
-
-          <div class="controls">
-            <label class="checkbox">
-              <input type="checkbox" ng-model="file.selected"/>{{file.relpath}}
-            </label>
-          </div>
-          <br /><br />
-        </div>
+      <div class="form-group selectFiles" ng-include="'selectFilesCheckBox.html'" ng-init="files=selectFiles.groupedFiles">
       </div>
     </fieldset>
   </form>

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
   <script src="js/libs/jquery-2.2.4.min.js"></script>
   <script src="js/libs/lodash-4.17.3.min.js"></script>
 
-  <script src="js/libs/angular.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.6.5/angular.js"></script>
 
   <script src="js/libs/angularui-bootstrap-tpls.min.js"></script>
   <script src="js/libs/bootstrap-filestyle.js"></script>
@@ -41,6 +41,7 @@
 
   <script src="js/directives/chunkbar.js"></script>
   <script src="js/directives/dgraph.js"></script>
+  <script src="js/directives/fileselect.js"></script>
   <script src="js/directives/fselect.js"></script>
   <script src="js/directives/textarea.js"></script>
 
@@ -1032,30 +1033,33 @@
 
   <!-- {{{ select files checkbox modal -->
 <script type="text/ng-template" id="selectFilesCheckBox.html">
-  <div ng-repeat="(folder,file) in files">
-    <!--is's a folder-->
-    <div ng-if="!file.index || file.index.toString().indexOf('object') >= 0">
-      <div class="controls">
-        <label class="checkbox">
-          <input type="checkbox"/>{{folder}}
-        </label>
-        <div class="form-group selectFiles" ng-include="'selectFilesCheckBox.html'" ng-init="files=file">
-        </div>
+  <div ng-repeat="(folderName,folder) in files.dirs">
+    <!--recursive folder-->
+
+    <div class="controls">
+      <!--click to toggle show the subfolders and files-->
+      <div class="checkbox" data-ng-click="folder.show=!folder.show">
+        <!-- The value of indeterminate="" can be bound to any angular expression -->
+        <input type="checkbox" ng-model="folder.selected" data-ng-click="$event.stopPropagation()" indeterminate="true"/>{{folderName}}
+        <span ng-show="!folder.show" class="control-label">{{ 'click the text to expand the folder' | translate }}</span>
+        <span ng-show="folder.show" class="control-label">{{ 'click the text to collapse the folder' | translate }}</span>
+      </div>
+      <div ng-show="folder.show" class="form-group selectFiles" ng-include="'selectFilesCheckBox.html'" ng-init="files=folder">
       </div>
     </div>
+  </div>
 
-    <!--is's a file-->
-    <div ng-if="file.index && file.index.toString().indexOf('object') < 0">
-      <label class="control-label">{{ 'Select to download' | translate }}</label>
+  <div ng-repeat="file in files.files">
+    <!--files-->
+    <label class="control-label">{{ 'Select to download' | translate }}</label>
 
-      <div class="controls">
-        <label class="checkbox">
-          <input type="checkbox" ng-model="file.selected"/>{{file.relpath}}
-        </label>
-      </div>
-      <br/>
-      <br/>
+    <div class="controls">
+      <label class="checkbox">
+        <input type="checkbox" ng-model="file.selected"/>{{file.relpath}}
+      </label>
     </div>
+    <br/>
+    <br/>
   </div>
 </script>
 <!-- }}} -->

--- a/js/ctrls/modal.js
+++ b/js/ctrls/modal.js
@@ -123,6 +123,23 @@ angular
       var self = this;
 
 	  this.files = _.cloneDeep(files);
+      var groupFile = function (files) {
+          var i, j, str, arr, folder = {}, tmp = folder;
+          for (i = 0; i < files.length; i++) {
+              str = files[i].relpath;
+              arr = str.split("/");
+              for (j = 0; j < arr.length - 1; j++) {
+                  if (!tmp[arr[j]]) {
+                      tmp[arr[j]] = {};
+                  }
+                  tmp = tmp[arr[j]];
+              }
+              tmp[arr[arr.length - 1]] = files[i];
+              tmp = folder;
+          }
+          return folder;
+      };
+      this.groupedFiles = groupFile(this.files);
       this.inst = $modal.open({
         templateUrl: "selectFiles.html",
         scope: scope,

--- a/js/ctrls/modal.js
+++ b/js/ctrls/modal.js
@@ -123,23 +123,60 @@ angular
       var self = this;
 
 	  this.files = _.cloneDeep(files);
-      var groupFile = function (files) {
-          var i, j, str, arr, folder = {}, tmp = folder;
-          for (i = 0; i < files.length; i++) {
-              str = files[i].relpath;
-              arr = str.split("/");
-              for (j = 0; j < arr.length - 1; j++) {
-                  if (!tmp[arr[j]]) {
-                      tmp[arr[j]] = {};
+      var groupFiles = function (files) {
+          var createSubFolder = function () {
+              var folder = {
+                  dirs      : {},
+                  files     : {},
+                  show      : false,
+                  _selected : false,
+                  change    : function () {
+                      for (var file in this.files) {
+                          if (this.files.hasOwnProperty(file)) {
+                              this.files[file].selected = this.selected;
+                          }
+                      }
+                      for (var folder in this.dirs) {
+                          if (this.dirs.hasOwnProperty(folder)) {
+                              this.dirs[folder].selected = this.selected;
+                          }
+                      }
+                      console.log(this);
                   }
-                  tmp = tmp[arr[j]];
-              }
-              tmp[arr[arr.length - 1]] = files[i];
+              };
+              Object.defineProperty(folder, "selected", {
+                  get : function () {
+                      return this._selected;
+                  },
+                  set : function (newValue) {
+                      this._selected = newValue;
+                      this.change();
+                  }
+              });
+              Object.defineProperty(folder, "indeterminate", {
+                  get : function () {
+                      return this._selected;
+                  }
+              });
+              return folder;
+          };
+          var folder = createSubFolder(),
+              tmp;
+          for (var i = 0; i < files.length; i++) {
               tmp = folder;
+              var str = files[i].relpath;
+              var arr = str.split("/");
+              for (var j = 0; j < arr.length - 1; j++) {
+                  if (!tmp.dirs[arr[j]]) {
+                      tmp.dirs[arr[j]] = createSubFolder();
+                  }
+                  tmp = tmp.dirs[arr[j]];
+              }
+              tmp.files[arr[arr.length - 1]] = files[i];
           }
           return folder;
       };
-      this.groupedFiles = groupFile(this.files);
+      this.groupedFiles = groupFiles(this.files);
       this.inst = $modal.open({
         templateUrl: "selectFiles.html",
         scope: scope,

--- a/js/ctrls/modal.js
+++ b/js/ctrls/modal.js
@@ -124,6 +124,14 @@ angular
 
 	  this.files = _.cloneDeep(files);
       var groupFiles = function (files) {
+          // sort files alphabetically
+          files.sort(function (a, b) {
+              if (a.relpath < b.relpath) {
+                  return -1;
+              } else {
+                  return 1;
+              }
+          });
           function OrganizedFolder () {
               this.dirs = {};
               this.files = [];

--- a/js/ctrls/modal.js
+++ b/js/ctrls/modal.js
@@ -128,47 +128,8 @@ angular
               this.dirs = {};
               this.files = [];
               this.show = false;
-              this._selected = false;
+              this.selected = true;
           }
-          OrganizedFolder.prototype.change = function () {
-              for (var i = 0; i < this.files.length; i++) {
-                  this.files[i].selected = this.selected;
-              }
-              for (var folder in this.dirs) {
-                  if (this.dirs.hasOwnProperty(folder)) {
-                      this.dirs[folder].selected = this.selected;
-                  }
-              }
-          };
-          Object.defineProperty(OrganizedFolder.prototype, "selected", {
-              get : function () {
-                  return this._selected;
-              },
-              set : function (newValue) {
-                  this._selected = newValue;
-                  this.change();
-              }
-          });
-          Object.defineProperty(OrganizedFolder.prototype, "indeterminate", {
-              get : function () {
-                  var allSeleted = true;
-                  var allNotSelected = true;
-                  for (var p in this.dirs) {
-                      if (this.dirs.hasOwnProperty(p)) {
-                          if (this.dirs[p].indeterminate) {
-                              return true;
-                          }
-                          allSeleted &= this.dirs[p].selected;
-                          allNotSelected &= !this.dirs[p].selected;
-                      }
-                  }
-                  for (var i = 0; i < this.files.length; i++) {
-                      allSeleted &= this.files[i].selected;
-                      allNotSelected &= !this.files[i].selected;
-                  }
-                  return !allSeleted && !allNotSelected;// is not determinate when either all selected either all not selected;
-              }
-          });
           var folder = new OrganizedFolder(), tmp;
           for (var i = 0; i < files.length; i++) {
               tmp = folder;
@@ -182,7 +143,6 @@ angular
               }
               tmp.files.push(files[i]);
           }
-          folder.change();
           return folder;
       };
       this.groupedFiles = groupFiles(this.files);

--- a/js/directives/fileselect.js
+++ b/js/directives/fileselect.js
@@ -1,57 +1,98 @@
 // watches changes in the file upload control (input[file]) and
 // puts the files selected in an attribute
-var app = angular.module("webui.directives.fileselect", []);
-app.directive("indeterminate", function () {
-    return {
-        // Restrict the directive so it can only be used as an attribute
-        restrict : "A",
+var app = angular.module("webui.directives.fileselect", ["webui.services.deps"]);
+app.directive("indeterminate", [
+    "$parse", function syncInput (parse) {
+        return {
+            require  : "ngModel",
+            // Restrict the directive so it can only be used as an attribute
+            restrict : "A",
 
-        link : function link (scope, elem, attr) {
-            // Whenever the bound value of the attribute changes we update
-            // the internal 'indeterminate' flag on the attached dom element
-            // use upward emit notification for change to prevent the performance penalty bring by $scope.$watch
-            elem[0].indeterminate = scope.$eval(attr.indeterminate);
-            scope.$on("childSelectedChange", function (event, options) {
-                elem[0].indeterminate = scope.$eval(attr.indeterminate);
-            });
-
-            /* var watcher = scope.$watch(attr.indeterminate, function (value) {
-             elem[0].indeterminate = value;
-             });
-
-             // Remove the watcher when the directive is destroyed
-             scope.$on("$destroy", function () {
-             watcher();
-             }); */
-        }
-    };
-});
-
-app.directive("monitor", function () {
-    return {
-        // Restrict the directive so it can only be used as an attribute
-        restrict : "A",
-
-        link : function link (scope, elem, attr) {
-            // Whenever the bound value of the attribute changes we update
-            // the internal 'indeterminate' flag on the attached dom element
-            elem.change(function () {
-                scope.$emit("childSelectedChange");
-            });
-        }
-    };
-});
-
-app.directive("selected", function () {
-    return {
-        // Restrict the directive so it can only be used as an attribute
-        restrict : "A",
-
-        link : function link (scope, elem, attr) {
-            elem[0].value = scope.$eval(attr.selected);
-            scope.$on("childSelectedChange", function (event, options) {
-                elem[0].value = scope.$eval(attr.selected);
-            });
-        }
-    };
-});
+            link : function link (scope, elem, attr, ngModelCtrl) {
+                // Whenever the bound value of the attribute changes we update
+                // use upward emit notification for change to prevent the performance penalty bring by $scope.$watch
+                var getter = parse(attr["ngModel"]);
+                var setter = getter.assign;
+                var children = []; // cache children input
+                var get = function () {
+                    return getter(scope);
+                };
+                // the internal 'indeterminate' flag on the attached dom element
+                var setIndeterminateState = function (newValue) {
+                    elem.prop("indeterminate", newValue);
+                };
+                var setModelValueWithoutSideEffect = function (newVal) {
+                    setter(scope, newVal);
+                    ngModelCtrl.$modelValue = newVal;
+                    ngModelCtrl.$viewValue = newVal;
+                    ngModelCtrl.$render();
+                };
+                var setWithSideEffect = function (newVal) {
+                    ngModelCtrl.$setViewValue(newVal);
+                    ngModelCtrl.$render();
+                };
+                var passIfLeafChild = function (callback) {
+                    return function () {
+                        if (children.length > 0) {
+                            callback.apply(this, arguments);
+                        }
+                    };
+                };
+                var passIfNotIsLeafChild = function (callback) {
+                    return function () {
+                        if (children.length === 0) {
+                            callback.apply(this, arguments);
+                        }
+                    };
+                };
+                var passThroughThisScope = function (callback) {
+                    return function (event) {
+                        if (event.targetScope !== event.currentScope) {
+                            return callback.apply(this, arguments);
+                        }
+                    };
+                };
+                if (attr["indeterminate"] && parse(attr["indeterminate"]).constant && !scope.$eval(attr["indeterminate"])) {
+                    // is leaf input, Only receive parent change and emit child change event
+                    setIndeterminateState(scope.$eval(attr["indeterminate"]));
+                    ngModelCtrl.$viewChangeListeners.push(passIfNotIsLeafChild(function () {
+                        scope.$emit("childSelectedChange");
+                    }));
+                    scope.$on("ParentSelectedChange", passThroughThisScope(
+                        function (event, newVal) {
+                            setWithSideEffect(newVal);
+                        }));
+                    scope.$emit("i'm child input", get);
+                    setWithSideEffect(get());
+                    scope.$emit("childSelectedChange");
+                } else {
+                    // init first time and only once
+                    // establish parent-child's relation
+                    scope.$on("i'm child input", passThroughThisScope(
+                        function (event, child) {
+                            children.push(child);
+                        })
+                    );
+                    var updateBaseOnChildrenState = function () {
+                        var allSelected = children.every(function (child) {
+                            return child();
+                        });
+                        var anySeleted = children.some(function (child) {
+                            return child();
+                        });
+                        setIndeterminateState(allSelected !== anySeleted);
+                        setWithSideEffect(allSelected);
+                    };
+                    // is not leaf input, Only receive child change and parent change event
+                    ngModelCtrl.$viewChangeListeners.push(passIfLeafChild(function () {
+                        if (!elem.prop("indeterminate")) { // emit when prop indeterminate is set to false
+                            scope.$broadcast("ParentSelectedChange", get());
+                        }
+                    }));
+                    // reset input state base on children inputs
+                    scope.$on("childSelectedChange", passThroughThisScope(passIfLeafChild(updateBaseOnChildrenState)));
+                }
+            }
+        };
+    }
+]);

--- a/js/directives/fileselect.js
+++ b/js/directives/fileselect.js
@@ -34,7 +34,7 @@ app.directive("indeterminate", [
                         }
                     };
                 };
-                var passIfNotIsLeafChild = function (callback) { // ensure to execute callback only when this input hasn't subinput
+                var passIfNotIsLeafChild = function (callback) { // ensure to execute callback only when this input hasn't any subinput
                     return function () {
                         if (children.length === 0) {
                             callback.apply(this, arguments);
@@ -48,44 +48,45 @@ app.directive("indeterminate", [
                         }
                     };
                 };
-                var passIfIsIndeterminate = function (callback) { // pass through the event from the scope where they sent
+                var passIfIsIndeterminate = function (callback) { // pass through the event when this input is indeterminate
                     return function () {
                         if (!elem.prop("indeterminate")) {
                             return callback.apply(this, arguments);
                         }
                     };
                 };
-                var catchEventOnlyOnce = function (callback) { // only fire once, and stop event's propagation
-                    return function (event) {
-                        callback.apply(this, arguments);
-                        return event.stopPropagation();
-                    };
-                };
+                /* var catchEventOnlyOnce = function (callback) { // only fire once, and stop event's propagation
+                 return function (event) {
+                 callback.apply(this, arguments);
+                 return event.stopPropagation();
+                 };
+                 }; */
                 if (attr["indeterminate"] && parse(attr["indeterminate"]).constant) {
                     setIndeterminateState(scope.$eval(attr["indeterminate"])); // set to default value (set in template)
                 }
                 if (attr["indeterminate"] && parse(attr["indeterminate"]).constant && !scope.$eval(attr["indeterminate"])) {
                     // when this input wont have subinput, they will only receive parent change and emit child change event
                     ngModelCtrl.$viewChangeListeners.push(passIfNotIsLeafChild(function () {
-                        scope.$emit("childSelectedChange", get());
+                        scope.$emit("childSelectedChange", get()); // notifies parents to change their state
                     }));
                     scope.$on("ParentSelectedChange", passThroughThisScope(passIfNotIsLeafChild(
                         function (event, newVal) {
                             setModelValueWithSideEffect(newVal); // set value to parent's value; this will cause listener to emit childChange event; this won't be a infinite loop
                         })));
                     // init first time and only once
-                    scope.$emit("i'm child input", get);
+                    scope.$emit("i'm child input", get); // traverses upwards toward the root scope notifying the listeners for keep reference to this input's value
                     scope.$emit("childSelectedChange", get()); // force emitted, and force the parent change their state base on children at first time
                 } else {
                     // establish parent-child's relation
                     // listen for the child emitted token
-                    scope.$on("i'm child input", passThroughThisScope(
+                    scope.$on("i'm child input", passThroughThisScope( // can't apply pass passIfIsLeafChild, at beginning all has not child input
                         function (event, child) {
                             children.push(child);
                         })
                     );
                     var updateBaseOnChildrenState = function (event, newChildValue) {
                         if ((cacheSelectedSubInputNumber + cacheNoSelectedSubInputNumber) !== children.length) {
+                            // cache childern state
                             cacheSelectedSubInputNumber = 0;
                             cacheNoSelectedSubInputNumber = 0;
                             for (var i = 0; i < children.length; i++) {
@@ -106,7 +107,7 @@ app.directive("indeterminate", [
                                 cacheNoSelectedSubInputNumber++;
                             }
                         }
-                        var allSelected = (cacheNoSelectedSubInputNumber === 0);
+                        var allSelected = (cacheNoSelectedSubInputNumber === 0); // if doesn't has any no selected input
                         var anySeleted = (cacheSelectedSubInputNumber > 0);
                         setIndeterminateState(allSelected !== anySeleted); // if at least one is selected, but not all then set input property indeterminate to true
                         setModelValueWithSideEffect(allSelected); // change binding model value and trigger onchange event

--- a/js/directives/fileselect.js
+++ b/js/directives/fileselect.js
@@ -1,0 +1,21 @@
+// watches changes in the file upload control (input[file]) and
+// puts the files selected in an attribute
+angular.module("webui.directives.fileselect", []).directive("indeterminate", function () {
+    return {
+        // Restrict the directive so it can only be used as an attribute
+        restrict : "A",
+
+        link : function link (scope, elem, attr) {
+            // Whenever the bound value of the attribute changes we update
+            // the internal 'indeterminate' flag on the attached dom element
+            var watcher = scope.$watch(attr.indeterminate, function (value) {
+                elem[0].indeterminate = value;
+            });
+
+            // Remove the watcher when the directive is destroyed
+            scope.$on("$destroy", function () {
+                watcher();
+            });
+        }
+    };
+});

--- a/js/directives/fileselect.js
+++ b/js/directives/fileselect.js
@@ -1,6 +1,7 @@
 // watches changes in the file upload control (input[file]) and
 // puts the files selected in an attribute
-angular.module("webui.directives.fileselect", []).directive("indeterminate", function () {
+var app = angular.module("webui.directives.fileselect", []);
+app.directive("indeterminate", function () {
     return {
         // Restrict the directive so it can only be used as an attribute
         restrict : "A",
@@ -8,13 +9,48 @@ angular.module("webui.directives.fileselect", []).directive("indeterminate", fun
         link : function link (scope, elem, attr) {
             // Whenever the bound value of the attribute changes we update
             // the internal 'indeterminate' flag on the attached dom element
-            var watcher = scope.$watch(attr.indeterminate, function (value) {
-                elem[0].indeterminate = value;
+            // use upward emit notification for change to prevent the performance penalty bring by $scope.$watch
+            elem[0].indeterminate = scope.$eval(attr.indeterminate);
+            scope.$on("childSelectedChange", function (event, options) {
+                elem[0].indeterminate = scope.$eval(attr.indeterminate);
             });
 
-            // Remove the watcher when the directive is destroyed
-            scope.$on("$destroy", function () {
-                watcher();
+            /* var watcher = scope.$watch(attr.indeterminate, function (value) {
+             elem[0].indeterminate = value;
+             });
+
+             // Remove the watcher when the directive is destroyed
+             scope.$on("$destroy", function () {
+             watcher();
+             }); */
+        }
+    };
+});
+
+app.directive("monitor", function () {
+    return {
+        // Restrict the directive so it can only be used as an attribute
+        restrict : "A",
+
+        link : function link (scope, elem, attr) {
+            // Whenever the bound value of the attribute changes we update
+            // the internal 'indeterminate' flag on the attached dom element
+            elem.change(function () {
+                scope.$emit("childSelectedChange");
+            });
+        }
+    };
+});
+
+app.directive("selected", function () {
+    return {
+        // Restrict the directive so it can only be used as an attribute
+        restrict : "A",
+
+        link : function link (scope, elem, attr) {
+            elem[0].value = scope.$eval(attr.selected);
+            scope.$on("childSelectedChange", function (event, options) {
+                elem[0].value = scope.$eval(attr.selected);
             });
         }
     };

--- a/js/directives/fileselect.js
+++ b/js/directives/fileselect.js
@@ -12,8 +12,10 @@ app.directive("indeterminate", [
                 // Whenever the bound value of the attribute changes we update
                 // use upward emit notification for change to prevent the performance penalty bring by $scope.$watch
                 var getter = parse(attr["ngModel"]);
-                var setter = getter.assign;
+                // var setter = getter.assign;
                 var children = []; // cache children input
+                var cacheSelectedSubInputNumber = 0;
+                var cacheNoSelectedSubInputNumber = 0;
                 var get = function () {
                     return getter(scope);
                 };
@@ -21,18 +23,18 @@ app.directive("indeterminate", [
                 var setIndeterminateState = function (newValue) {
                     elem.prop("indeterminate", newValue);
                 };
-                var setWithSideEffect = function (newVal) {
+                var setModelValueWithSideEffect = function (newVal) { // will cause to emit corresponding events
                     ngModelCtrl.$setViewValue(newVal);
                     ngModelCtrl.$render();
                 };
-                var passIfLeafChild = function (callback) { // ensure to execute callback when this input have one or more subinputs
+                var passIfIsLeafChild = function (callback) { // ensure to execute callback only when this input has one or more subinputs
                     return function () {
                         if (children.length > 0) {
                             callback.apply(this, arguments);
                         }
                     };
                 };
-                var passIfNotIsLeafChild = function (callback) { // ensure to execute callback when this input havent subinput
+                var passIfNotIsLeafChild = function (callback) { // ensure to execute callback only when this input hasn't subinput
                     return function () {
                         if (children.length === 0) {
                             callback.apply(this, arguments);
@@ -46,19 +48,27 @@ app.directive("indeterminate", [
                         }
                     };
                 };
+                var catchEventOnlyOnce = function (callback) { // only fire once, and stop event's propagation
+                    return function (event) {
+                        callback.apply(this, arguments);
+                        return event.stopPropagation();
+                    };
+                };
+                if (attr["indeterminate"] && parse(attr["indeterminate"]).constant) {
+                    setIndeterminateState(scope.$eval(attr["indeterminate"])); // set to default value (set in template)
+                }
                 if (attr["indeterminate"] && parse(attr["indeterminate"]).constant && !scope.$eval(attr["indeterminate"])) {
-                    // is leaf input, Only receive parent change and emit child change event
-                    setIndeterminateState(scope.$eval(attr["indeterminate"]));
+                    // when this input wont have subinput, they will only receive parent change and emit child change event
                     ngModelCtrl.$viewChangeListeners.push(passIfNotIsLeafChild(function () {
-                        scope.$emit("childSelectedChange");
+                        scope.$emit("childSelectedChange", get());
                     }));
-                    scope.$on("ParentSelectedChange", passThroughThisScope(
+                    scope.$on("ParentSelectedChange", passThroughThisScope(passIfNotIsLeafChild(
                         function (event, newVal) {
-                            setWithSideEffect(newVal); // set value to parent's value; this will cause listener to emit childChange event; this won't be a infinite loop
-                        }));
+                            setModelValueWithSideEffect(newVal); // set value to parent's value; this will cause listener to emit childChange event; this won't be a infinite loop
+                        })));
                     // init first time and only once
                     scope.$emit("i'm child input", get);
-                    scope.$emit("childSelectedChange"); // force emitted, and force the parent change their state base on children at first time
+                    scope.$emit("childSelectedChange", get()); // force emitted, and force the parent change their state base on children at first time
                 } else {
                     // establish parent-child's relation
                     // listen for the child emitted token
@@ -67,25 +77,42 @@ app.directive("indeterminate", [
                             children.push(child);
                         })
                     );
-                    var updateBaseOnChildrenState = function () {
-                        var allSelected = children.every(function (child) {
-                            return child();
-                        });
-                        var anySeleted = children.some(function (child) {
-                            return child();
-                        });
+                    var updateBaseOnChildrenState = function (event, newChildValue) {
+                        if ((cacheSelectedSubInputNumber + cacheNoSelectedSubInputNumber) !== children.length) {
+                            cacheSelectedSubInputNumber = 0;
+                            cacheNoSelectedSubInputNumber = 0;
+                            for (var i = 0; i < children.length; i++) {
+                                if (children[i]()) {
+                                    cacheSelectedSubInputNumber += 1;
+                                } else {
+                                    cacheNoSelectedSubInputNumber += 1;
+                                }
+                            }
+                        } else {
+                            // no need for recalculated children state
+                            // just make a few change to cache value
+                            if (newChildValue) {
+                                cacheSelectedSubInputNumber++;
+                                cacheNoSelectedSubInputNumber--;
+                            } else {
+                                cacheSelectedSubInputNumber--;
+                                cacheNoSelectedSubInputNumber++;
+                            }
+                        }
+                        var allSelected = (cacheNoSelectedSubInputNumber === 0);
+                        var anySeleted = (cacheSelectedSubInputNumber > 0);
                         setIndeterminateState(allSelected !== anySeleted); // if at least one is selected, but not all then set input property indeterminate to true
-                        setWithSideEffect(allSelected);
+                        setModelValueWithSideEffect(allSelected);
                     };
                     // is not leaf input, Only receive child change and parent change event
-                    ngModelCtrl.$viewChangeListeners.push(passIfLeafChild(function () {
+                    ngModelCtrl.$viewChangeListeners.push(passIfIsLeafChild(function () {
                         // emit when property indeterminate is set to false, prevent recursively emitting event from parent to children, children to parent
                         if (!elem.prop("indeterminate")) {
                             scope.$broadcast("ParentSelectedChange", get());
                         }
                     }));
                     // reset input state base on children inputs
-                    scope.$on("childSelectedChange", passThroughThisScope(passIfLeafChild(updateBaseOnChildrenState)));
+                    scope.$on("childSelectedChange", passThroughThisScope(passIfIsLeafChild(updateBaseOnChildrenState)));
                 }
             }
         };

--- a/js/init.js
+++ b/js/init.js
@@ -4,7 +4,7 @@ var webui = angular.module('webui', [
   'webui.services.modals', 'webui.services.alerts',
   'webui.services.settings', 'webui.services.settings.filters',
   'webui.filters.bytes','webui.filters.url',
-  'webui.directives.chunkbar', 'webui.directives.dgraph', 'webui.directives.fselect',
+  'webui.directives.chunkbar', 'webui.directives.dgraph', 'webui.directives.fselect', "webui.directives.fileselect",
   'webui.ctrls.download', 'webui.ctrls.nav', 'webui.ctrls.modal', 'webui.ctrls.alert',
   'webui.ctrls.props',
   // external deps


### PR DESCRIPTION
add folder structure to select files in select-file option #76, and then we can make less clicks for select or unselect files, by making click in their parent folder input, that will apply same change to all subfolders and files inside it, useful when torrent file contains many files. 

*folder
****subfolder
********file
****subfolder
********subfolder
********more subfolder... and so on
********file
********file
******** ...more files
*file
*file
..more files
![2017-07-29 1](https://user-images.githubusercontent.com/11367542/28748165-00eb15cc-74b1-11e7-8721-9efcf2cdc1ca.png)

