### PR TITLE
Using POST instead of JSONP for JSON-RPC calls to enable *.torrent file uploads

### DIFF
--- a/js/services/rpc/jsoncall.js
+++ b/js/services/rpc/jsoncall.js
@@ -7,28 +7,24 @@ angular
       this.avgTimeout = 2000;
       this.serverConf = conf;
     },
-    encode: function(obj) {
-      return base64.btoa( JSON.stringify(obj) );
-    },
     ariaRequest: function(url, funcName, params, success, error) {
       var startTime = new Date();
       var conn = this;
-      $.ajax({
+      $.post({
         url: url,
         timeout: this.avgTimeout,
-        data: {
+        contentType: 'application/json',
+        data: JSON.stringify({
           jsonrpc: 2.0,
           id: 'webui',
           method: funcName,
-          params: params && params.length ? this.encode(params) : undefined
-        },
+          params: params
+        }),
         success: function(data) {
           conn.avgTimeout =  2000 + 3 * (new Date() - startTime);
           return success(data);
         },
-        error: error,
-        dataType: 'jsonp',
-        jsonp: 'jsoncallback'
+        error: error
       });
     },
     invoke: function(opts) {


### PR DESCRIPTION
It's currently impossible to upload a torrent file to aria2 using Web UI. The reason is that depending on the size (10-100KB) the file content gets URL-encoded and exceeds the URI limit. The RPC server on the aria2 side refuses to handle this request.

Using POST transport instead of JSONP solves this problem.