### PR TITLE
Update arm dockerfile to aria 1.32 and enforce aria2 best practices

### DIFF
--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,19 +1,18 @@
 FROM resin/rpi-raspbian
 
 # less priviledge user, the id should map the user the downloaded files belongs to
-RUN groupadd -r aria && useradd -r -g aria aria -u 1000
+RUN groupadd -r aria && useradd -m -r -g aria aria -u 1000
 
 # webui + aria2
 RUN apt-get update \
-        && apt-get install -y busybox curl \
-        git \
+        && apt-get install -y busybox curl git \
         make g++ libssl-dev nettle-dev libgmp-dev libssh2-1-dev libc-ares-dev libxml2-dev zlib1g-dev libsqlite3-dev pkg-config libxml2-dev libcppunit-dev autoconf automake autotools-dev autopoint libtool \
-        && ARIA2_VERSION="1.31.0" \
+        && ARIA2_VERSION="1.32.0" \
         && mkdir aria_build && cd aria_build \
         && curl -L https://github.com/aria2/aria2/releases/download/release-"$ARIA2_VERSION"/aria2-"$ARIA2_VERSION".tar.gz > aria2.tar.gz \
         && tar -xzf aria2.tar.gz \
         && cd aria2-$ARIA2_VERSION \
-        && autoreconf -i  && ./configure && make \
+        && autoreconf -i && ./configure && make \
         && mv src/aria2c /usr/bin/ \
         && cd ../.. \
         && rm -rf aria_build \
@@ -30,7 +29,7 @@ RUN GITHUB_REPO="https://github.com/tianon/gosu" \
   && chmod +x /usr/local/bin/gosu
 
 # goland install (compile source code for ARM since no version are currently available)
-RUN curl -L "https://storage.googleapis.com/golang/go1.8.linux-armv6l.tar.gz" > go.tar.gz \
+RUN curl -L "https://storage.googleapis.com/golang/go1.9.1.linux-armv6l.tar.gz" > go.tar.gz \
   && tar -xzf go.tar.gz -C /usr/local \
   && export GOROOT="/usr/local/go" && export GOPATH=`pwd` \
   && $GOROOT/bin/go get github.com/mattn/goreman && $GOROOT/bin/go build -o /usr/local/bin/goreman github.com/mattn/goreman \
@@ -39,10 +38,12 @@ RUN curl -L "https://storage.googleapis.com/golang/go1.8.linux-armv6l.tar.gz" > 
   && unset GOROOT && unset GOPATH
 
 # goreman setup
-RUN echo "web: gosu aria /bin/busybox httpd -f -p 8080 -h /webui-aria2\nbackend: gosu aria /usr/bin/aria2c --conf-path=/data/.aria2/aria2.conf" /data/downloads/*.torrent > Procfile
+RUN echo "web: gosu aria /bin/busybox httpd -f -p 8080 -h /webui-aria2\nbackend: gosu aria /usr/bin/aria2c --conf-path=/home/aria/.aria2/aria2.conf" /data/downloads/*.torrent > Procfile
 
 # aria2 downloads directory
-VOLUME /data
+VOLUME /data/downloads
+# aria2 conf directory
+VOLUME /home/aria/.aria2
 
 # aria2 RPC port, map as-is or reconfigure webui
 EXPOSE 6800/tcp

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -38,7 +38,7 @@ RUN curl -L "https://storage.googleapis.com/golang/go1.9.1.linux-armv6l.tar.gz" 
   && unset GOROOT && unset GOPATH
 
 # goreman setup
-RUN echo "web: gosu aria /bin/busybox httpd -f -p 8080 -h /webui-aria2\nbackend: gosu aria /usr/bin/aria2c --conf-path=/home/aria/.aria2/aria2.conf" /data/downloads/*.torrent > Procfile
+RUN echo "web: gosu aria /bin/busybox httpd -f -p 8080 -h /webui-aria2\nbackend: gosu aria /usr/bin/aria2c --conf-path=/home/aria/.aria2/aria2.conf /data/downloads/*.torrent" > Procfile
 
 # aria2 downloads directory
 VOLUME /data/downloads

--- a/README.md
+++ b/README.md
@@ -68,17 +68,22 @@ Build it (may take several hours due to the aria2 compilation process. Don't pan
 docker build -f Dockerfile.arm -t yourname/webui-aria2 .
 ```
 Prepare the host volume:
-This image required few file to be mounted in the container's `/data` folder.
+This image required few file to be mounted in the container.
 ```
-.aria2/session.txt  (empty file)
-.aria2/aria2.log    (empty file)
-.aria2/aria2.conf   (aria2 configuration file, not webui-aria2 conf) must contains at least `enable-rpc=true` and `rpc-listen-all=true`
-./downloads/        (where the downloaded files goes)
+/home/aria/aria2/session.txt  (empty file)
+/home/aria/aria2/aria2.log    (empty file)
+/home/aria/aria2/aria2.conf   (aria2 configuration file, not webui-aria2 conf) must contains at least `enable-rpc=true` and `rpc-listen-all=true`
+/data/downloads/        (where the downloaded files goes)
 ```
 
 Run it
 ```
-docker run --restart=always -d -v /home/<USER>/data/aria2:/data -p 6800:6800 -p 9100:8080 --name="webui-aria2" yourname/webui-aria2
+docker run --restart=always \
+        -v /home/<USER>/data/aria2/downloads:/data/downloads \
+        -v /home/<USER>/data/aria2/.aria2:/home/aria/.aria2 \
+        -p 6800:6800 -p 9100:8080 \
+        --name="webui-aria2" \
+        -d yourname/webui-aria2
 ```
 
 Support


### PR DESCRIPTION
aria2 use to search for config and save files at `$HOME/.aria2/...`, even if some file path can be customized, (session, config, dht) some others seems not to be. The raspberry Dockerfile now respects this and split configuration mount point from downloaded file mount point.

Also, **updated from aria2 1.31 to 1.32**.