### PR TITLE
support config server connection config in uri

### DIFF
--- a/js/init.js
+++ b/js/init.js
@@ -27,7 +27,7 @@ function mergeTranslation(translation, base) {
 	return translation;
 }
 
-webui.config(['$translateProvider', function ($translateProvider) {
+webui.config(function ($translateProvider, $locationProvider) {
   $translateProvider
       .translations('en_US', translations.en_US)
       .translations('nl_NL', mergeTranslation(translations.nl_NL, translations.en_US))
@@ -44,7 +44,12 @@ webui.config(['$translateProvider', function ($translateProvider) {
       .translations('cs_CZ', mergeTranslation(translations.cs_CZ, translations.en_US))
       .useSanitizeValueStrategy('escapeParameters')
       .determinePreferredLanguage();
-}]);
+
+      $locationProvider.html5Mode({
+        enabled: true,
+        requireBase: false
+      });
+});
 
 $(function() {
   if (!String.prototype.startsWith) {

--- a/js/services/rpc/rpc.js
+++ b/js/services/rpc/rpc.js
@@ -19,6 +19,15 @@ function(syscall, globalTimeout, alerts, utils, rootScope, uri, authconf, filter
   // try at the start, so that it is presistant even when default authconf works
   if(cookieConf) configurations.unshift(cookieConf);
 
+  if (uri.search().host) {
+    configurations.unshift(uri.search());
+    configurations[0].auth = {
+      token: configurations[0].token,
+      user: configurations[0].username,
+      pass: configurations[0].password
+    };
+  }
+
   if (['http', 'https'].indexOf(uri.protocol()) != -1 && uri.host() != 'localhost') {
     configurations.push({
       host: uri.host(),


### PR DESCRIPTION
Add a feature that you can pass server settings by the uri:

- `<path_to_webui>/?host=<rpc_host>&port=<rpc_port>&path=<rpc_path>&encrypt=<1 or 0>&token=<rpc_token>`
- `<path_to_webui>/?host=<rpc_host>&port=<rpc_port>&path=<rpc_path>&encrypt=<1 or 0>&username=<rpc_username>&password=<rpc_password>`

The config passed by uri will take precedence of any other available configurations.
Super handy to keep different server connections in bookmark.