### PR TITLE
Adding Content-Type support for html, css, and js

### DIFF
--- a/node-server.js
+++ b/node-server.js
@@ -8,6 +8,18 @@ http.createServer(function(request, response) {
 	var uri = url.parse(request.url).pathname,
 		filename = path.join(process.cwd(), uri);
 
+	var extname = path.extname(filename);
+	var contentType = 'text/html';
+	switch (extname) {
+		case '.js':
+		contentType = 'text/javascript';
+		break;
+		case '.css':
+		contentType = 'text/css';
+		break;
+	}
+	
+	
 	fs.exists(filename, function(exists) {
 		if(!exists) {
 			response.writeHead(404, {"Content-Type": "text/plain"});
@@ -25,7 +37,7 @@ http.createServer(function(request, response) {
 				response.end();
 				return;
 			}
-			response.writeHead(200);
+			response.writeHead(200, {'Content-Type': contentType});
 			response.write(file, "binary");
 			response.end();
 		});


### PR DESCRIPTION
When used with Nginx proxy pass "node node-server.js" command will not pass Content-Type to Nginx which will result in having index.html displayed as a text file. No html, no CSS, and no JS execution on the browser!