### PR TITLE
Change node-server.js to use containing folder's path as basis

### DIFF
--- a/node-server.js
+++ b/node-server.js
@@ -3,11 +3,12 @@ var http = require("http"),
   path = require("path"),
   fs = require("fs");
 port = process.argv[2] || 8888;
+base = path.dirname(process.argv[1])
 
 http
   .createServer(function(request, response) {
     var uri = url.parse(request.url).pathname,
-      filename = path.join(process.cwd(), "docs", uri);
+      filename = path.join(base, "docs", uri);
 
     var extname = path.extname(filename);
     var contentType = "text/html";


### PR DESCRIPTION
Hi:
This one liner changes to use the path of the folder containing node-server.js instead of relying on cwd. So the user can just alias the command in their bash script without having to cd out first