### PR TITLE
Fix Dockerfile goreman dowmload latest build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ RUN GITHUB_REPO="https://github.com/tianon/gosu" \
 # goreman supervisor install latest
 RUN GITHUB_REPO="https://github.com/mattn/goreman" \
   && LATEST=`curl -s  $GITHUB_REPO"/releases/latest" | grep -Eo "v[0-9]*.[0-9]*.[0-9]*"` \
-  && curl -L $GITHUB_REPO"/releases/download/"$LATEST"/goreman_linux_amd64.zip" > goreman.zip \
-  && unzip goreman.zip && mv /goreman /usr/local/bin/goreman && rm -R goreman*
+  && curl -L $GITHUB_REPO"/releases/download/"$LATEST"/goreman_"$LATEST"_linux_amd64.tar.gz" > goreman.tar.gz \
+  && tar -xvf goreman.tar.gz && mv /goreman_"$LATEST"_linux_amd64/goreman /usr/local/bin/goreman && rm -R goreman*
 
 # goreman setup
 RUN echo "web: gosu dummy /bin/busybox httpd -f -p 8080 -h /webui-aria2\nbackend: gosu dummy /usr/bin/aria2c --enable-rpc --rpc-listen-all --dir=/data" > Procfile


### PR DESCRIPTION
This PR fix the download url of goreman and the file format.
goreman updated the file for Linux to `tar.gz`